### PR TITLE
Link fixups

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -25,6 +25,7 @@ cc_library(
         "pieces.cpp",
         "square.cpp",
         "squares_board.cpp",
+        "split.cpp",
     ],
 	hdrs = [
         "board.hpp",

--- a/src/pieces.cpp
+++ b/src/pieces.cpp
@@ -9,6 +9,8 @@
 using namespace std;
 
 
+Piece::~Piece() {}
+
 Piece::Piece(Side colour, int file, int rank) : side(colour) {
     position = SquaresBoard::get(file, rank);
 };

--- a/src/pieces.hpp
+++ b/src/pieces.hpp
@@ -17,7 +17,7 @@ public:
     const enum Side                 side;
 
                                     Piece(Side, int, int);
-                                    ~Piece();
+    virtual                         ~Piece();
 
     static Piece *                  make_piece(char, Side, int, int);
     bool                            isAt(int, int) const;


### PR DESCRIPTION
I just had to fix two trivial issues and it worked, including building all the gtest stuff.

The errors I fixed, I can't imagine them ever _not_ causing a problem, so I am not sure how clang was managing to compile it prior to v9.0.0... For sure, the Linux errors from gcc (pasted below) are far more friendly than the one you pated from clang.

Why don't you try to switch to gcc? gcc rocks!

Building main:
```
ben@lenovo: {bedser} /scratch/schach$ bazel build //src:schach
INFO: Analysed target //src:schach (0 packages loaded).
INFO: Found 1 target...
Target //src:schach up-to-date:
  bazel-bin/src/schach
INFO: Elapsed time: 0.939s, Critical Path: 0.63s
INFO: Build completed successfully, 3 total actions
```
Running main: (got a segfault :-(  )
```
ben@lenovo: {bedser} /scratch/schach$ ls -l bazel-bin/src/schach
-r-xr-xr-x 1 ben ben 175432 Nov 19 16:36 bazel-bin/src/schach
ben@lenovo: {bedser} /scratch/schach$ bazel-bin/src/schach
Position: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
Segmentation fault (core dumped)
```
Running tests:
```
ben@lenovo: (link-fixups) /scratch/schach$ bazel test ...
INFO: Analysed 6 targets (1 packages loaded).
INFO: Found 3 targets and 3 test targets...
INFO: Elapsed time: 1.586s, Critical Path: 1.19s
INFO: Build completed successfully, 14 total actions
//test:fen_test                                                          PASSED in 0.1s
//test:piece_test                                                        PASSED in 0.1s
//test:square_test                                                       PASSED in 0.1s

Executed 3 out of 3 tests: 3 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.

```